### PR TITLE
feat: reviews tab enhancements 1

### DIFF
--- a/web-client/src/App.tsx
+++ b/web-client/src/App.tsx
@@ -44,7 +44,12 @@ function App() {
         </NoRenderOnPath>
         <Routes>
           <Route path="/" element={<ReviewQueuePage />} />
-          <Route path="/pulls/pullrequest/:owner/:repoName/:prnumber" element={<PRDetailsPage />} />
+          <Route path="/pulls/pullrequest/:owner/:repoName/:prnumber">
+            <Route path="reviews" element={<PRDetailsPage tab="reviews" />} />
+            <Route path="commits" element={<PRDetailsPage tab="commits" />} />
+            <Route path="details" element={<PRDetailsPage tab="details" />} />
+            <Route path="" element={<PRDetailsPage />} />
+          </Route>
           <Route path="/repositories" element={<RepositoriesPage />} />
           <Route path="/analytics" element={<AnalyticsPage />} />
           <Route path="/createPR" element={<PRCreationPage />} />

--- a/web-client/src/components/PRCreate/CommitHistory.tsx
+++ b/web-client/src/components/PRCreate/CommitHistory.tsx
@@ -38,7 +38,6 @@ function CommitHistory() {
         }
       } catch (error) {
         console.error("Error fetching PR info:", error);
-        setTimeout(fetchCommitInfo, 1000);
       }
     };
     fetchCommitInfo();

--- a/web-client/src/components/ReviewsTab/DiffCommentEditor.tsx
+++ b/web-client/src/components/ReviewsTab/DiffCommentEditor.tsx
@@ -1,5 +1,5 @@
 import { IconCaretDownFilled, IconX } from "@tabler/icons-react";
-import { Button, Divider, Group, ActionIcon, Paper, Select, Textarea, Menu } from "@mantine/core";
+import { Button, Divider, Group, ActionIcon, Paper, Select, Textarea, Menu, Title } from "@mantine/core";
 import { useState } from "react";
 import { ReviewComment, ReviewCommentDecoration } from "../../tabs/ModifiedFilesTab";
 
@@ -75,7 +75,8 @@ function DiffCommentEditor({ onAdd, onCancel }: DiffCommentEditorProps) {
 
   return (
     <Paper withBorder p="sm">
-      <Group justify="end">
+      <Group justify="space-between" mb="xs">
+        <Title order={6}>Review Comment</Title>
         <ActionIcon color="darkred" title="Cancel" onClick={onCancel}>
           <IconX size="16px" />
         </ActionIcon>

--- a/web-client/src/components/ReviewsTab/FileDiffView.tsx
+++ b/web-client/src/components/ReviewsTab/FileDiffView.tsx
@@ -1,6 +1,6 @@
-import { Box, Group, Text, ActionIcon } from "@mantine/core";
+import { Box, Group, Text, ActionIcon, Tooltip, Textarea, Paper, Title } from "@mantine/core";
 import { useHover } from "@mantine/hooks";
-import { IconPlus } from "@tabler/icons-react";
+import { IconPlus, IconX } from "@tabler/icons-react";
 import { useState } from "react";
 import { DiffLine, DiffLineType, FileDiff } from "../../utility/diff-types";
 import DiffCommentEditor from "./DiffCommentEditor";
@@ -41,6 +41,7 @@ function DiffLineNonMarkerView({
 }: DiffLineNonMarkerViewProps) {
   const { hovered, ref } = useHover();
   const [addingComment, setAddingComment] = useState(false);
+  const [addingSelfNote, setAddingSelfNote] = useState(false);
 
   return (
     <Box>
@@ -73,17 +74,33 @@ function DiffLineNonMarkerView({
             width: "min-content",
           }}
         >
-          <ActionIcon
-            pos="absolute"
-            style={{ visibility: hovered && hasStartedReview ? "visible" : "hidden" }}
-            size="xs"
-            onClick={() => setAddingComment(true)}
-          >
-            <IconPlus size="16px" />
-          </ActionIcon>
+          <Group pos="absolute" style={{ visibility: hovered && hasStartedReview ? "visible" : "hidden" }} gap="xs">
+            <Tooltip label="Add review comment">
+              <ActionIcon size="xs" onClick={() => setAddingComment(true)}>
+                <IconPlus size="16px" />
+              </ActionIcon>
+            </Tooltip>
+            <Tooltip label="Add note to self">
+              <ActionIcon size="xs" color="gray" onClick={() => setAddingSelfNote(true)}>
+                <IconPlus size="16px" />
+              </ActionIcon>
+            </Tooltip>
+          </Group>
           <code style={{ whiteSpace: "pre-wrap" }}>{l.content}</code>
         </Box>
       </Group>
+
+      {addingSelfNote && (
+        <Paper withBorder p="sm">
+          <Group justify="space-between" mb="xs">
+            <Title order={6}>Self Note</Title>
+            <ActionIcon color="darkred" title="Discard" onClick={() => setAddingSelfNote(false)}>
+              <IconX size="16px" />
+            </ActionIcon>
+          </Group>
+          <Textarea autosize placeholder="Note..." />
+        </Paper>
+      )}
 
       {addingComment && (
         <DiffCommentEditor

--- a/web-client/src/components/Tab.tsx
+++ b/web-client/src/components/Tab.tsx
@@ -1,26 +1,28 @@
-import { Tabs } from "@mantine/core";
-import { useState } from "react";
-//import { IconPhoto, IconMessageCircle, IconSettings } from '@tabler/icons-react';
+import { Anchor, Tabs } from "@mantine/core";
+import { PRDetailsPageTabName } from "../pages/PRDetailsPage";
+import { Link } from "react-router-dom";
 
 interface TabComponentProps {
-  tabs: string[];
-  updateTab: (newTab: string | null) => void;
+  tabs: PRDetailsPageTabName[];
+  currentTab: PRDetailsPageTabName;
 }
 
-function TabComp({ tabs, updateTab }: TabComponentProps) {
-  const [activeTab, setActiveTab] = useState<string | null>(tabs[0]);
-
-  const handleChange = (newValue: string | null) => {
-    setActiveTab(newValue);
-    updateTab(newValue);
+function TabComp({ tabs, currentTab }: TabComponentProps) {
+  const getLinkTarget = (targetTab: PRDetailsPageTabName) => {
+    if (targetTab === currentTab) return ".";
+    if (targetTab === tabs[0]) return "..";
+    if (currentTab === tabs[0]) return targetTab;
+    return `../${targetTab}`;
   };
-  //const iconStyle = { width: rem(12), height: rem(12) };
+
   return (
-    <Tabs color="#415A77" variant="pills" radius="md" defaultValue={activeTab} onChange={handleChange}>
+    <Tabs color="#415A77" variant="pills" radius="md" value={currentTab ?? tabs[0]}>
       <Tabs.List>
         {tabs.map((tab) => (
           <Tabs.Tab key={tab} value={tab} leftSection="">
-            {tab.charAt(0).toUpperCase() + tab.slice(1)}
+            <Anchor component={Link} to={getLinkTarget(tab)} relative="path" size="sm" td="none" c="white">
+              {tab.charAt(0).toUpperCase() + tab.slice(1)}
+            </Anchor>
           </Tabs.Tab>
         ))}
       </Tabs.List>

--- a/web-client/src/pages/PRDetailsPage.tsx
+++ b/web-client/src/pages/PRDetailsPage.tsx
@@ -3,7 +3,6 @@ import CommentsTab from "../tabs/CommentsTab.tsx";
 import CommitsTab from "../tabs/CommitsTab.tsx";
 import { Box, Badge, rem, Group, UnstyledButton } from "@mantine/core";
 import TabComp from "../components/Tab.tsx";
-import * as React from "react";
 import { IconGitPullRequest } from "@tabler/icons-react";
 import PrContextTab from "../tabs/PrContextTab.tsx";
 import { useEffect, useState } from "react";
@@ -34,9 +33,19 @@ export interface PullRequest {
   assignees: Assignee[];
 }
 
-function PRDetailsPage() {
+export type PRDetailsPageTabName = "comments" | "commits" | "details" | "reviews";
+const tabs: PRDetailsPageTabName[] = ["comments", "commits", "details", "reviews"];
+
+export interface PRDetailsPageProps {
+  tab?: PRDetailsPageTabName;
+}
+
+function PRDetailsPage(props: PRDetailsPageProps) {
   const { owner, repoName, prnumber } = useParams();
   const [pullRequest, setPullRequest] = useState<PullRequest | null>(null);
+
+  const currentTab = props.tab ?? tabs[0];
+  console.log(currentTab);
 
   useEffect(() => {
     const fetchPRInfo = async () => {
@@ -54,14 +63,6 @@ function PRDetailsPage() {
     };
     fetchPRInfo();
   }, [owner, prnumber, repoName]);
-
-  const tabs = ["comments", "commits", "details", "modified files"];
-
-  const [currentTab, setCurrentTab] = React.useState<string | null>(tabs[0]);
-
-  const updateTab = (newTab: string | null) => {
-    setCurrentTab(newTab);
-  };
 
   return (
     <div style={{ textAlign: "left", marginLeft: 100 }}>
@@ -109,10 +110,10 @@ function PRDetailsPage() {
 
       <Box>
         <br />
-        <TabComp tabs={tabs} updateTab={updateTab} />
+        <TabComp tabs={tabs} currentTab={currentTab} />
         <br />
         <Box>
-          {currentTab === "modified files" && <ModifiedFilesTab />}
+          {currentTab === "reviews" && <ModifiedFilesTab />}
           {currentTab === "comments" && pullRequest && <CommentsTab pullRequest={pullRequest} />}
           {currentTab === "details" && <PrContextTab />}
           {currentTab === "commits" && <CommitsTab />}

--- a/web-client/src/pages/ReviewQueuePage.tsx
+++ b/web-client/src/pages/ReviewQueuePage.tsx
@@ -98,8 +98,6 @@ function ReviewQueuePage() {
         }
       } catch (error) {
         console.error("Error fetching PR info:", error);
-        // Retry fetching PR info after a delay
-        setTimeout(fetchPRInfo, 1000); // Retry after 3 seconds
       }
     };
 

--- a/web-client/src/tabs/ModifiedFilesTab.tsx
+++ b/web-client/src/tabs/ModifiedFilesTab.tsx
@@ -12,7 +12,6 @@ import {
   Textarea,
   Paper,
   Avatar,
-  TextInput,
   Badge,
 } from "@mantine/core";
 import FileDiffView from "../components/ReviewsTab/FileDiffView";
@@ -355,6 +354,7 @@ function ModifiedFilesTab() {
         </Box>
       </Collapse>
 
+      <Title order={4}>Review Verdicts</Title>
       {mainComments.map((c, i) => (
         <Paper key={i} withBorder radius="md" shadow="lg" my="sm" p="sm">
           <Group>
@@ -370,17 +370,16 @@ function ModifiedFilesTab() {
                 })}
               </Text>
             </div>
-            <Badge ml="auto">
+            <Badge ml="auto" color={c.verdict === "approve" ? "lime" : c.verdict === "reject" ? "crimson" : "gray"}>
               {c.verdict === "approve" ? "Approved" : c.verdict === "reject" ? "Requested changes" : "Comment"}
             </Badge>
           </Group>
 
-          <h5>{c.content}</h5>
-
-          <TextInput placeholder="Reply..."></TextInput>
+          <Text py="sm">{c.content}</Text>
         </Paper>
       ))}
 
+      <Title order={4}>Modified Files</Title>
       {mockFileDiffs.map((f) => (
         <FileDiffView
           key={f.fileName}


### PR DESCRIPTION
## Changes

- Modify PR details page routes to include tab state in URL
- Add basic reply capability to diff review comments
- Remove the `setTimeout`s that cause infinite requests
  - I don't think we need to keep retrying when requests fail, just let the page fail (ideally gracefully) and refresh to retry
- Some visual improvements (margins, titles, colors, etc.)
- Add a new diff hover action item to be able to leave notes to self during review