### PR TITLE
bugfix: null data fixed on get_comments

### DIFF
--- a/api-server/Core/Entities/IssueCommentInfo.cs
+++ b/api-server/Core/Entities/IssueCommentInfo.cs
@@ -4,6 +4,7 @@ namespace CS.Core.Entities
     {
         public long id { get; set; }
         public string? author { get; set; }
+        public string? avatar { get; set; }
         public string? body { get; set; }
         public string? label { get; set; }
         public string? decoration { get; set; }

--- a/api-server/Web/Controllers/GitHubController.cs
+++ b/api-server/Web/Controllers/GitHubController.cs
@@ -1039,6 +1039,7 @@ public class GitHubController : ControllerBase
                             {
                                 id = comm.Id,
                                 author = comm.User.Login,
+                                avatar = comm.User.AvatarUrl,
                                 body = comm.Body,
                                 label = null,
                                 decoration = null,
@@ -1065,10 +1066,11 @@ public class GitHubController : ControllerBase
                                 {
                                     id = comm.Id,
                                     author = comm.User.Login,
+                                    avatar = comm.User.AvatarUrl,
                                     body = parsed_message,
-                                    label = reader.GetString(0),
-                                    decoration = reader.GetString(1),
-                                    status = reader.GetString(2),
+                                    label = reader.IsDBNull(0) ? null : reader.GetString(0),
+                                    decoration = reader.IsDBNull(1) ? null : reader.GetString(1),
+                                    status = reader.IsDBNull(2) ? null : reader.GetString(2),
                                     createdAt = comm.CreatedAt,
                                     updatedAt = comm.UpdatedAt,
                                     association = comm.AuthorAssociation.StringValue


### PR DESCRIPTION
Apparently, database reader does not expect any null value. It needs to be assigned explicitly.

Also added the avatar urls of the comment authors.