### PR TITLE
fix: the bug in addCommentReply is fixed

### DIFF
--- a/api-server/Web/Controllers/GitHubController.cs
+++ b/api-server/Web/Controllers/GitHubController.cs
@@ -1312,7 +1312,6 @@ public class GitHubController : ControllerBase
         string decorated_body = replied_to.Body.Contains("<!--Using HubReview-->")
             ? $"<!--Using HubReview-->\n> {replied_to.Body.Remove(0, 22)}\n> {replied_to.HtmlUrl} \n\n{req.body}"
             : $"<!--Using HubReview-->\n> {replied_to.Body}\n> {replied_to.HtmlUrl} \n\n{req.body}";
-            
         var comment = await client.Issue.Comment.Create(owner, repoName, prnumber, decorated_body);
 
         return Ok(comment);

--- a/api-server/Web/Controllers/GitHubController.cs
+++ b/api-server/Web/Controllers/GitHubController.cs
@@ -1308,7 +1308,11 @@ public class GitHubController : ControllerBase
         var client = GetNewClient(_httpContextAccessor?.HttpContext?.Session.GetString("AccessToken"));
 
         var replied_to = await client.Issue.Comment.Get(owner, repoName, req.reply_to_id);
-        string decorated_body = $"<!--Using HubReview-->\n> {replied_to.Body.Remove(0, 22)}\n> {replied_to.HtmlUrl} \n\n{req.body}";
+
+        string decorated_body = replied_to.Body.Contains("<!--Using HubReview-->")
+            ? $"<!--Using HubReview-->\n> {replied_to.Body.Remove(0, 22)}\n> {replied_to.HtmlUrl} \n\n{req.body}"
+            : $"<!--Using HubReview-->\n> {replied_to.Body}\n> {replied_to.HtmlUrl} \n\n{req.body}";
+
         var comment = await client.Issue.Comment.Create(owner, repoName, prnumber, decorated_body);
 
         return Ok(comment);

--- a/api-server/Web/Controllers/GitHubController.cs
+++ b/api-server/Web/Controllers/GitHubController.cs
@@ -1307,7 +1307,7 @@ public class GitHubController : ControllerBase
     {
         var client = GetNewClient(_httpContextAccessor?.HttpContext?.Session.GetString("AccessToken"));
 
-        var replied_to = await client.Issue.Comment.Get(owner, repoName, req.reply_to_id);
+        var replied_to = await client.Issue.Comment.Get(owner, repoName, req.replyToId);
 
         string decorated_body = replied_to.Body.Contains("<!--Using HubReview-->") ? $"<!--Using HubReview-->\n> {replied_to.Body.Remove(0, 22)}\n> {replied_to.HtmlUrl} \n\n{req.body}" : $"<!--Using HubReview-->\n> {replied_to.Body}\n> {replied_to.HtmlUrl} \n\n{req.body}";
 

--- a/api-server/Web/Controllers/GitHubController.cs
+++ b/api-server/Web/Controllers/GitHubController.cs
@@ -1309,9 +1309,8 @@ public class GitHubController : ControllerBase
 
         var replied_to = await client.Issue.Comment.Get(owner, repoName, req.reply_to_id);
 
-        string decorated_body = replied_to.Body.Contains("<!--Using HubReview-->")
-            ? $"<!--Using HubReview-->\n> {replied_to.Body.Remove(0, 22)}\n> {replied_to.HtmlUrl} \n\n{req.body}"
-            : $"<!--Using HubReview-->\n> {replied_to.Body}\n> {replied_to.HtmlUrl} \n\n{req.body}";
+        string decorated_body = replied_to.Body.Contains("<!--Using HubReview-->") ? $"<!--Using HubReview-->\n> {replied_to.Body.Remove(0, 22)}\n> {replied_to.HtmlUrl} \n\n{req.body}" : $"<!--Using HubReview-->\n> {replied_to.Body}\n> {replied_to.HtmlUrl} \n\n{req.body}";
+
         var comment = await client.Issue.Comment.Create(owner, repoName, prnumber, decorated_body);
 
         return Ok(comment);


### PR DESCRIPTION
To avoid having double hidden phrases, I was removing the phrase from the replied comment. I did not consider the comments made from GH, they do not have this hidden phrase so those comments were causing OutOfRange error because of the remove function.